### PR TITLE
Exclude Properties and XML files from the build

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -120,7 +120,7 @@ war {
 
 license {
     header rootProject.file('../LICENSE.md')
-    excludes(["**/*.html", "**/*.mustache", "**/*.sql", "**/package-info.java", "**/keystore.jks"])
+    excludes(["**/*.html", "**/*.mustache", "**/*.sql", "**/package-info.java", "**/*.xml", "**/*.properties", "**/keystore.jks"])
     strictCheck true
 }
 


### PR DESCRIPTION
The build failed due to Missing headers error caused by gradle license plugin. Excluding the properties and xml files successfully builds the code from the repository.